### PR TITLE
Update owsmanager.css

### DIFF
--- a/css/owsmanager.css
+++ b/css/owsmanager.css
@@ -52,7 +52,7 @@
     box-shadow: 0 0 6px white;
 }
 .config_button {
-    display:none !important;
+    /* display:none !important; */
     border-radius: 14px;
     -moz-border-radius: 14px;
     -webkit-border-radius: 14px;


### PR DESCRIPTION
It is necessary to comment the display:none attribute in order to show the menu button when widget initializes.
